### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-bootvar-unix.opam
+++ b/mirage-bootvar-unix.opam
@@ -16,7 +16,7 @@ build: [
 ]
 
 depends: [
-  "dune" {build}
+  "dune"
   "lwt"
   "parse-argv"
   "ocaml" {>= "4.04.2"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.